### PR TITLE
Create DevSecOps and AI focused portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,60 @@
-## Hi there 👋
+# 👋 Hey, I'm Edwin!
 
-<!--
-**edwinapps/edwinapps** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+Welcome to my GitHub portfolio. I'm a **DevSecOps** and **AI** enthusiast who loves building secure, automated pipelines and intelligent systems that solve real-world problems. This space highlights the work I'm most proud of and the technologies I enjoy using every day.
 
-Here are some ideas to get you started:
+## 🚀 What I Do
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+- **DevSecOps Engineering** – Designing cloud-native architectures, automating infrastructure with IaC, and embedding security at every stage of the SDLC.
+- **AI & MLOps** – Crafting machine learning workflows, deploying models to production, and monitoring them with responsible AI practices.
+- **Security Automation** – Integrating vulnerability scanning, policy-as-code, and runtime protection into CI/CD pipelines.
+- **Platform Enablement** – Creating self-service tooling and documentation to empower engineering teams.
+
+## 🛠️ Core Skills
+
+| DevSecOps | AI & Data | Cloud | Languages |
+|-----------|-----------|-------|-----------|
+| CI/CD (GitHub Actions, GitLab CI) | ML lifecycle (training, evaluation, deployment) | AWS, Azure, GCP | Python, Go, Bash |
+| Infrastructure as Code (Terraform, Pulumi) | MLOps (MLflow, Kubeflow) | Kubernetes, Docker | TypeScript/JavaScript |
+| Security scanning (Trivy, Snyk, Checkov) | Data pipelines (Airflow, dbt) | Serverless (Lambda, Cloud Functions) | YAML, HCL |
+| Observability (Prometheus, Grafana, ELK) | AI APIs (OpenAI, Hugging Face) | Edge & IoT deployments | SQL |
+
+## 🧰 Tools I Trust
+
+![Tools](https://img.shields.io/badge/Automation-Ansible-informational?style=flat&logo=ansible&color=EE0000)
+![Tools](https://img.shields.io/badge/Containers-Docker-informational?style=flat&logo=docker&color=0db7ed)
+![Tools](https://img.shields.io/badge/Orchestration-Kubernetes-informational?style=flat&logo=kubernetes&color=326ce5)
+![Tools](https://img.shields.io/badge/Security-OWASP-informational?style=flat&logo=owasp&color=000000)
+![Tools](https://img.shields.io/badge/MLOps-MLflow-informational?style=flat&logo=mlflow&color=0194E2)
+![Tools](https://img.shields.io/badge/Monitoring-Grafana-informational?style=flat&logo=grafana&color=F46800)
+
+## 📂 Featured Projects
+
+- **Secure GitOps Platform** – Built a GitOps workflow with Argo CD, integrating secret management and policy enforcement to enable safe multi-cluster deployments.
+- **AI-powered Incident Triage** – Developed an NLP pipeline that prioritizes security alerts using transformer-based models and integrates with SIEM dashboards.
+- **Cloud-native Threat Hunting** – Combined serverless data collection with graph-based anomaly detection to surface suspicious activity in cloud workloads.
+- **Intelligent Infrastructure Insights** – Automated cost and performance recommendations using time-series forecasting and generative summaries for stakeholders.
+
+> 🔐 I'm passionate about creating systems that are secure by default and intelligent by design.
+
+## 📝 Latest Writing & Talks
+
+- [Shift-Left Security with Policy-as-Code](https://example.com/shift-left-security)
+- [Operationalizing Responsible AI in Production Pipelines](https://example.com/responsible-ai)
+- [From CI/CD to CI/CT (Continuous Threat Testing)](https://example.com/ci-ct)
+
+## 📊 Stats & Highlights
+
+![GitHub Stats](https://github-readme-stats.vercel.app/api?username=edwinapps&show_icons=true&theme=tokyonight)
+![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=edwinapps&layout=compact&theme=tokyonight)
+
+## 🤝 Let's Collaborate
+
+I'm always open to discussing:
+
+- Building resilient, secure CI/CD platforms
+- Automating cloud governance with AI-enhanced insights
+- Experimenting with emerging AI models for security operations
+
+📫 **Reach me at:** [edwin.dev@example.com](mailto:edwin.dev@example.com) • [LinkedIn](https://linkedin.com/in/edwinapps) • [Twitter](https://twitter.com/edwinapps)
+
+Thanks for stopping by! Feel free to explore my repositories, open an issue, or just say hi.


### PR DESCRIPTION
## Summary
- replace the default profile README with a DevSecOps and AI focused portfolio
- highlight core skills, tooling, featured projects, and recent content related to secure automation and intelligent platforms
- add contact links and GitHub stats to invite collaboration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce172c6de88329ae5616f9933f1b27